### PR TITLE
Fix potential crash on didEndDisplayingCell

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		AA7AA5BF284B73F10094F04B /* FeedAcceptanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7AA5BE284B73F10094F04B /* FeedAcceptanceTests.swift */; };
 		AA7AA5C4284B7C8B0094F04B /* HTTPClientStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7AA5C3284B7C8B0094F04B /* HTTPClientStub.swift */; };
 		AA7AA5C7284B7DB50094F04B /* InMemoryFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7AA5C6284B7DB50094F04B /* InMemoryFeedStore.swift */; };
+		AA7AA5F1284CBA990094F04B /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7AA5F0284CBA990094F04B /* UIView+TestHelpers.swift */; };
 		AA96AB30283EA16C003559B5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA96AB2F283EA16C003559B5 /* AppDelegate.swift */; };
 		AA96AB32283EA16C003559B5 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA96AB31283EA16C003559B5 /* SceneDelegate.swift */; };
 		AA96AB37283EA16C003559B5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA96AB35283EA16C003559B5 /* Main.storyboard */; };
@@ -94,6 +95,7 @@
 		AA7AA5BE284B73F10094F04B /* FeedAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAcceptanceTests.swift; sourceTree = "<group>"; };
 		AA7AA5C3284B7C8B0094F04B /* HTTPClientStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientStub.swift; sourceTree = "<group>"; };
 		AA7AA5C6284B7DB50094F04B /* InMemoryFeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryFeedStore.swift; sourceTree = "<group>"; };
+		AA7AA5F0284CBA990094F04B /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 		AA96AB2C283EA16C003559B5 /* EssentialApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EssentialApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA96AB2F283EA16C003559B5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AA96AB31283EA16C003559B5 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				AA7AA5AC284B71070094F04B /* UIButton+TestHelpers.swift */,
 				AA7AA5B0284B71070094F04B /* UIImage+TestHelpers.swift */,
 				AA7AA5B1284B71070094F04B /* UIRefreshControl+TestHelpers.swift */,
+				AA7AA5F0284CBA990094F04B /* UIView+TestHelpers.swift */,
 			);
 			path = "UIKit Helpers";
 			sourceTree = "<group>";
@@ -407,6 +410,7 @@
 				AA7AA5B6284B71070094F04B /* UIRefreshControl+TestHelpers.swift in Sources */,
 				AAE296DF284212C400885482 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				AA7AA5B4284B71070094F04B /* UIImage+TestHelpers.swift in Sources */,
+				AA7AA5F1284CBA990094F04B /* UIView+TestHelpers.swift in Sources */,
 				AA7AA5B7284B71070094F04B /* UIButton+TestHelpers.swift in Sources */,
 				AAE296EE28426D3B00885482 /* FeedLoaderStub.swift in Sources */,
 				AA7AA5BD284B72F80094F04B /* FeedUIIntegrationTests.swift in Sources */,

--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -55,7 +55,6 @@ final class FeedUIIntegrationTests: XCTestCase {
         let image1 = makeImage(description: nil, location: "another location")
         let image2 = makeImage(description: "another description", location: "a location")
         let image3 = makeImage(description: nil, location: nil)
-
         let (sut, loader) = makeSUT()
 
         sut.loadViewIfNeeded()
@@ -67,6 +66,20 @@ final class FeedUIIntegrationTests: XCTestCase {
         sut.simulateUserInitiatedFeedReload()
         loader.completeFeedLoading(with: [image0, image1, image2, image3], at: 1)
         assertThat(sut, isRendering: [image0, image1, image2, image3])
+    }
+
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+        
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+        
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
     }
 
     func test_errorView_doesNotRenderErrorOnLoad() {

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegration Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegration Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -26,8 +26,7 @@ extension FeedUIIntegrationTests {
     }
 
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
-        sut.tableView.layoutIfNeeded()
-        RunLoop.current.run(until: Date())
+        sut.view.enforceLayoutCycle()
 
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegration Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegration Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -26,6 +26,9 @@ extension FeedUIIntegrationTests {
     }
 
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }
@@ -33,5 +36,11 @@ extension FeedUIIntegrationTests {
         feed.enumerated().forEach { index, image in
             assertThat(sut, hasViewConfiguredFor: image, at: index, file: file, line: line)
         }
+
+        executeRunLoopToCleanUpReferences()
+    }
+
+    private func executeRunLoopToCleanUpReferences() {
+        RunLoop.current.run(until: Date())
     }
 }

--- a/EssentialApp/EssentialAppTests/Helpers/UIKit Helpers/UIView+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/UIKit Helpers/UIView+TestHelpers.swift
@@ -1,0 +1,15 @@
+//
+//  UIView+TestHelpers.swift
+//  EssentialAppTests
+//
+//  Created by TCode on 5/6/22.
+//
+
+import UIKit
+
+extension UIView {
+    func enforceLayoutCycle() {
+        layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+    }
+}

--- a/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -9,9 +9,11 @@ import UIKit
 import EssentialFeed
 
 final public class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching {
-    private var refreshController: FeedRefreshViewController?
     public let errorView = ErrorView()
-    
+
+    private var refreshController: FeedRefreshViewController?
+    private var loadingControllers = [IndexPath: FeedImageCellController]()
+
     private var tableModel = [FeedImageCellController]() {
         didSet { tableView.reloadData() }
     }
@@ -40,6 +42,7 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
 
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
 
@@ -66,11 +69,14 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
 
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        return tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
 
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }
 


### PR DESCRIPTION
When updating the table model and reloading the table, `UIKit` calls `didEndDisplayingCell` for each removed cell that was previously visible. Since we're canceling requests in this method, we could be sending messages to the new models or potentially crashing in case the new table model has fewer items than the previous one!

This is not a big problem at the moment since items cannot be removed from the feed. But we cannot assume the backend will keep this behavior going further.